### PR TITLE
Fix github logo enlarging on window resize

### DIFF
--- a/src/components/GitLogo.svelte
+++ b/src/components/GitLogo.svelte
@@ -1,9 +1,10 @@
 <script>
 	export let gitUrl;
+	export let height = 32;
 </script>
 
 <div class={$$props.class}>
-	<a href={gitUrl}>
+	<a href={gitUrl} style="height:{height}px">
 		{#if gitUrl}
 			{#if gitUrl.startsWith('https://github.com')}
 				<svg viewBox="0 0 24 24"><path
@@ -59,8 +60,6 @@
 
 <style>
 	a {
-		box-sizing: border-box;
-		height: 100%;
 		padding: 2px;
 	}
 	svg {

--- a/src/routes/PackagePage.svelte
+++ b/src/routes/PackagePage.svelte
@@ -41,7 +41,7 @@
 		{:then pkg}
 			<header>
 				<h2>{pkg.name}</h2>
-				<GitLogo gitUrl={pkg.git} />
+				<GitLogo gitUrl={pkg.git} height="64" />
 			</header>
 			<h3>
 				<NavLink to="/author/{pkg.author}">by {pkg.author}</NavLink>


### PR DESCRIPTION
Here's the bug in question:

![github_logo](https://user-images.githubusercontent.com/2174211/103467499-42510980-4d58-11eb-9f0b-08d7a4210b31.gif)
