### PR TITLE
git: Enforce LF across different systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+


### PR DESCRIPTION
Hello 🤗

You can use a [`.gitattributes`](https://www.git-scm.com/docs/gitattributes#_end_of_line_conversion) file to make Git normalize line endings to LF and prevent accidental commits with CRLF line endings 🙌

Thank you for your time.